### PR TITLE
Fix audit call argument mismatch

### DIFF
--- a/services/auth/main.py
+++ b/services/auth/main.py
@@ -40,7 +40,7 @@ def login(payload: OTPRequest) -> dict[str, bool]:
         raise HTTPException(status_code=400, detail="Email or phone required")
     code = "000000"  # demo OTP
     _otps[target] = code
-    audit("send_otp", user_id=None, endpoint="/login", metadata=target)
+    audit("send_otp", user_id=None, endpoint="/login", meta=target)
     track("platform_link_success", {"target": target})
     return {"otp_sent": True}
 
@@ -56,7 +56,7 @@ def verify(payload: OTPVerifyRequest) -> TokenResponse:
     access = prefix + uuid4().hex
     refresh = prefix + uuid4().hex
     _refresh_tokens[refresh] = target
-    audit("verify_otp", user_id=None, endpoint="/verify", metadata=target)
+    audit("verify_otp", user_id=None, endpoint="/verify", meta=target)
     track("offer_view", {"user": target})
     return TokenResponse(access_token=access, refresh_token=refresh)
 

--- a/services/ledger/main.py
+++ b/services/ledger/main.py
@@ -66,7 +66,7 @@ def create_loan(
     _loans[loan_id] = loan
     if idempotency_key:
         _idempotency_keys.add(idempotency_key)
-    audit("create_loan", user_id=1, endpoint="/loans", metadata=str(loan_id))
+    audit("create_loan", user_id=1, endpoint="/loans", meta=str(loan_id))
     track("loan_disbursed", {"loan_id": loan_id})
     return loan
 
@@ -100,7 +100,7 @@ def create_repayment(
         "create_repayment",
         user_id=1,
         endpoint="/repayments",
-        metadata=str(repayment_id),
+        meta=str(repayment_id),
     )
     track("repayment_success", {"repayment_id": repayment_id})
     return repayment


### PR DESCRIPTION
## Summary
- use `meta` parameter for audit logging in auth service
- use `meta` parameter for audit logging in ledger service

## Testing
- `bun run lint`
- `bun run format` *(fails: code style issues in 47 files)*
- `bun run typecheck`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_68549397bdb8833389068b0a52ee0599