### PR TITLE
Configure Expo scripts

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,15 @@
+const { getDefaultConfig } = require('@expo/metro-config');
+const path = require('path');
+
+const projectRoot = path.resolve(__dirname, 'apps/mobile');
+const config = getDefaultConfig(projectRoot);
+
+config.watchFolders = [
+  path.resolve(__dirname, 'node_modules'),
+  projectRoot,
+];
+
+config.projectRoot = projectRoot;
+
+module.exports = config;
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "test": "npm run test:mobile && npm run test:services",
     "test:mobile": "npm --prefix apps/mobile run test",
     "test:services": "python -m pytest tests/",
+    "start": "expo start --config apps/mobile/app.json",
+    "android": "expo run:android --config apps/mobile/app.json",
+    "ios": "expo run:ios --config apps/mobile/app.json",
+    "web": "expo start --web --config apps/mobile/app.json",
     "lint": "eslint .",
     "format": "prettier --write .",
     "type-check": "npm --prefix apps/mobile run type-check"


### PR DESCRIPTION
## Summary
- add Expo scripts to root package.json for easier mobile development
- set up shared metro config to target the mobile project

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685720e63ee88333bf4e1e57911f12a0