### PR TITLE
Configure Expo scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,9 @@ If you want to run the automated tests:
 ```bash
 npm test
 ```
+If you see an error like `jest: not found`, install the dependencies first with:
+```bash
+npm install
+```
 
 That's it! You can now explore the project and start developing.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
 # Gignancing
+
+This project contains a web and mobile app built with React and Expo. Follow these steps to get it running on your computer or phone.
+
+## Requirements
+
+- **Node.js** (download from [nodejs.org](https://nodejs.org)).
+- **Git** (or download the repository as a ZIP file).
+- **Expo Go** app on your iPhone or Android phone (free from the app store).
+
+## Setup
+
+1. If you downloaded a ZIP, extract it to a folder of your choice. Otherwise clone the repo with Git.
+2. Open a terminal (Command Prompt on Windows, Terminal on macOS/Linux).
+3. Navigate to the project folder, for example:
+   ```bash
+   cd path/to/gignancing
+   ```
+4. Install dependencies:
+   ```bash
+   npm install
+   ```
+   The install step also installs the mobile app dependencies automatically.
+
+## Running the App
+
+### Mobile (Expo)
+
+1. Start the Expo development server:
+   ```bash
+   npm start
+   ```
+2. A QR code will appear in the terminal or browser. Open the Expo Go app on your phone and scan the code to launch the mobile app.
+
+### Web Version
+
+Run the web build in your browser with:
+```bash
+npm run web
+```
+This opens the app at `http://localhost:19006`.
+
+## Building for Deployment
+
+To create a production build (for example for Vercel), run:
+```bash
+npm run build
+```
+The output will be in the `dist` folder.
+
+## Running Tests
+
+If you want to run the automated tests:
+```bash
+npm test
+```
+
+That's it! You can now explore the project and start developing.

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,15 @@
+const { getDefaultConfig } = require('@expo/metro-config');
+const path = require('path');
+
+const projectRoot = path.resolve(__dirname, 'apps/mobile');
+const config = getDefaultConfig(projectRoot);
+
+config.watchFolders = [
+  path.resolve(__dirname, 'node_modules'),
+  projectRoot,
+];
+
+config.projectRoot = projectRoot;
+
+module.exports = config;
+

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "npm --prefix apps/mobile run start",
-    "build": "npm --prefix apps/mobile run build",
+    "build": "vite build",
     "test": "npm run test:mobile && npm run test:services",
     "test:mobile": "npm --prefix apps/mobile run test",
     "test:services": "python -m pytest tests/",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "test": "npm run test:mobile && npm run test:services",
     "test:mobile": "npm --prefix apps/mobile run test",
     "test:services": "python -m pytest tests/",
+    "start": "expo start --config apps/mobile/app.json",
+    "android": "expo run:android --config apps/mobile/app.json",
+    "ios": "expo run:ios --config apps/mobile/app.json",
+    "web": "expo start --web --config apps/mobile/app.json",
     "lint": "eslint .",
     "format": "prettier --write .",
     "type-check": "npm --prefix apps/mobile run type-check"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "web": "expo start --web --config apps/mobile/app.json",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "type-check": "npm --prefix apps/mobile run type-check"
+    "type-check": "npm --prefix apps/mobile run type-check",
+    "postinstall": "npm --prefix apps/mobile install"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary
- add Expo scripts to root package.json for easier mobile development
- set up shared metro config to target the mobile project

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685720e63ee88333bf4e1e57911f12a0